### PR TITLE
cuPHY CRC: initialize schUserIdxs on the simple API path, and correct the timing test's success assertion

### DIFF
--- a/cuPHY/src/cuphy/crc/crc.cu
+++ b/cuPHY/src/cuphy/crc/crc.cu
@@ -304,6 +304,10 @@ cuphyStatus_t launch(
     desc.pOutputTBCRCs    = d_tbCRCs;
     desc.pTbPrmsArray     = d_tbPrmsArray;
     desc.reverseBytes     = reverseBytes;
+    // Initialize schUserIdxs to identity for the simple API path; without this,
+    // the kernel reads uninitialized indices and produces wrong CRCs on
+    // heterogeneous-TB inputs (single-CB and multi-CB TBs in the same batch).
+    for(uint32_t i = 0; i < nTBs; ++i) desc.schUserIdxs[i] = i;
 
     // Because the kernel is now grid constant, we do not need to copy the descriptor to GPU memory
 

--- a/cuPHY/src/cuphy/crc/crcTest.cu
+++ b/cuPHY/src/cuphy/crc/crcTest.cu
@@ -1261,7 +1261,7 @@ TEST(CRCTest, UplinkPuschWithTiming)
 {
     // Test with timing enabled
     int result = CRC_GPU_UPLINK_PUSCH_TEST(true);
-    EXPECT_EQ(result, 0) << "CRC test with timing enabled failed";
+    EXPECT_EQ(result, 1) << "CRC test with timing enabled failed";
 }
 
 TEST(PuschRxCrcDecodeTest, SetupFunction)


### PR DESCRIPTION
Fixes two coupled defects in the cuPHY uplink CRC path, reported as #34 and #36.

They are submitted together because they cannot be merged independently: fixing #34 alone makes `CRCTest.UplinkPuschWithTiming` start failing, since that test asserts the opposite success value from its sister test.

## 1. `desc.schUserIdxs` is never initialized on the simple CRC API path (#34)

`launch()` in `cuPHY/src/cuphy/crc/crc.cu` builds `puschRxCrcDecodeDescr_t` on the host and populates every field except `schUserIdxs[]`. Both CRC kernels index per-TB metadata through it:

```cpp
uint16_t ueIdx     = desc.schUserIdxs[blockIdx.y];  // crc.cu:63, crc.cu:189
uint16_t prevUeIdx = desc.schUserIdxs[i - 1];       // crc.cu:91, crc.cu:211
```

The descriptor is allocated with `cudaHostAlloc(..., cudaHostAllocDefault)` and is not zeroed, so the kernels index `pTbPrmsArray` with whatever was left in the pinned buffer. When every TB in a batch happens to resolve to the same metadata entry the result is still correct, which is why this went unnoticed. On heterogeneous batches — single-CB and multi-CB transport blocks mixed in one call — it selects the wrong `tbPrms` entry and yields deterministic CRC corruption.

The richer API path already does this: `cuphyPuschRxCrcDecodeSetup()` copies from the caller-supplied array at `crc.cu:1200`. The simple API accepts no user-index argument, so identity (`schUserIdxs[i] = i`) is the mapping its callers implicitly assume.

The loop is bounded. `nTBs` is rejected above `MAX_N_TBS_PER_CELL_GROUP_SUPPORTED` at `crc.cu:256`, and that constant is exactly the declared size of `schUserIdxs[]` in `crc_decode.hpp:29`, so the write cannot overrun the array.

## 2. `CRCTest.UplinkPuschWithTiming` asserts the wrong success value (#36)

`CRC_GPU_UPLINK_PUSCH_TEST()` returns 1 for success, and its sister test agrees:

```cpp
EXPECT_EQ(CRC_GPU_UPLINK_PUSCH_TEST(false), 1);   // CRC_GPU_UPLINK_PUSCH.24B_24A
```

The timing variant asserts the opposite:

```cpp
int result = CRC_GPU_UPLINK_PUSCH_TEST(true);
EXPECT_EQ(result, 0) << "CRC test with timing enabled failed";   // crcTest.cu:1264
```

This assertion passed only because the defect above made the function return 0 for an unrelated reason — the two bugs masked each other. Once the `schUserIdxs` initialization lands, `CRC_GPU_UPLINK_PUSCH_TEST(true)` returns 1 and this test fails. Aligned to the same success-equals-1 contract as the non-timing test.

## Verification

Per the reproducers in #34 and #36, on DGX Spark / GB10 (sm_121), CUDA 13.1.1, driver 590.48.01, container `nvcr.io/nvidia/aerial/aerial-cuda-accelerated-ran:26-1-cubb`: `CRC_GPU_UPLINK_PUSCH.24B_24A` fails with mismatching CB CRCs and TB data before this change and passes after it, with `CRCTest.UplinkPuschWithTiming` remaining green.

Both changes are confined to the CRC unit; no public API, descriptor layout, or kernel signature is altered.

Fixes #34
Fixes #36
