### PR TITLE
testMAC: derive DPDK/DOCA library path from host architecture in run_l2sa.sh

### DIFF
--- a/cuPHY-CP/testMAC/scripts/run_l2sa.sh
+++ b/cuPHY-CP/testMAC/scripts/run_l2sa.sh
@@ -137,10 +137,13 @@ if [ "$DOCA" = "" ]; then
     export DOCA=1
 fi
 
+# Debian multiarch directory name, e.g. x86_64-linux-gnu or aarch64-linux-gnu
+LIB_ARCH=$(arch)-linux-gnu
+
 if [ "$DOCA" = "1" ]; then
-    DPDK_LINK_PATH=/opt/mellanox/doca/lib/x86_64-linux-gnu:/opt/mellanox/dpdk/lib/x86_64-linux-gnu
+    DPDK_LINK_PATH=/opt/mellanox/doca/lib/$LIB_ARCH:/opt/mellanox/dpdk/lib/$LIB_ARCH
 else
-    DPDK_LINK_PATH=$cuBB_SDK/gpu-dpdk/$BUILD/install/lib/x86_64-linux-gnu
+    DPDK_LINK_PATH=$cuBB_SDK/gpu-dpdk/$BUILD/install/lib/$LIB_ARCH
 fi
 
 


### PR DESCRIPTION
Fixes #37.

`cuPHY-CP/testMAC/scripts/run_l2sa.sh` hardcodes the `x86_64-linux-gnu` Debian multiarch directory when assembling `DPDK_LINK_PATH`:

```sh
if [ "$DOCA" = "1" ]; then
    DPDK_LINK_PATH=/opt/mellanox/doca/lib/x86_64-linux-gnu:/opt/mellanox/dpdk/lib/x86_64-linux-gnu
else
    DPDK_LINK_PATH=$cuBB_SDK/gpu-dpdk/$BUILD/install/lib/x86_64-linux-gnu
fi
```

That path is then exported as `LD_LIBRARY_PATH` for `l2_adapter_cuphycontroller_scf`, `ru_emulator` and `test_mac`. On aarch64 hosts the directories are `aarch64-linux-gnu`, so the exported path points at directories that do not exist and the SCF L2 Adapter Standalone run cannot resolve the DPDK / DOCA shared libraries. This affects DGX Spark / GB10, Grace, and BlueField-3 ARM.

The fix derives the multiarch directory from `$(arch)`, which this same script already uses a few lines above to select the build directory:

```sh
if [[ -d $cuBB_SDK/build-$(arch) ]]; then
    BUILD=build-$(arch)
fi
```

It resolves to `x86_64-linux-gnu` on x86_64 and `aarch64-linux-gnu` on aarch64, so existing x86_64 behaviour is byte-for-byte unchanged.

The same architecture mapping is already applied elsewhere in the tree — `testBenches/doca_samples/doca_gpunetio_send_wait_time/{run,build,run_sanitizer}.sh` build a `LIB_ARCH` variable the same way. This change brings `run_l2sa.sh` in line with that.

## Verification

`run_l2sa.sh` was the only executable script under `cuPHY-CP/` still carrying the hardcoded triplet. After this change, `grep -rn x86_64-linux-gnu` over the tree reports it only in places where it is either intentional or inert: the DOCA sample scripts (which already select `LIB_ARCH` by architecture), the `cuPHY/cmake/toolchains/{x86-64,r750,devkit}` cross-compilation files, `cuMAC/CMakeLists.txt`, and two non-executable files under `cuPHY-CP/aerial-fh-driver/` (`app/fh_generator/README.md` and `.gitattributes`).
