### PR TITLE
5GModel: fix channelSet case in genPerfTVs.py ('AllChannels' -> 'allChannels')

### DIFF
--- a/5GModel/aerial_mcore/examples/genPerfTVs.py
+++ b/5GModel/aerial_mcore/examples/genPerfTVs.py
@@ -42,10 +42,10 @@ if args.only_gen_lp:
     eng.genLP_POC2(args.pattern)
 else:
     # Generate perf pattern
-    eng.genPerfPattern(args.pattern, 'AllChannels', args.exec_cmd)  # Use exec_cmd from command line argument
+    eng.genPerfPattern(args.pattern, 'allChannels', args.exec_cmd)  # Use exec_cmd from command line argument
 
     # Alternative method to generate perf pattern using runRegression
-    # eng.runRegression(['PerfPattern'], args.pattern, ['AllChannels'])
+    # eng.runRegression(['PerfPattern'], args.pattern, ['allChannels'])
 
 toc = time.time()
 print(f"Elapsed time: {toc-tic} seconds")


### PR DESCRIPTION
Fixes #38.

`5GModel/aerial_mcore/examples/genPerfTVs.py` passes the channel set as `'AllChannels'`:

```python
eng.genPerfPattern(args.pattern, 'AllChannels', args.exec_cmd)
```

`genPerfPattern.m` validates that argument against a case-sensitive list and raises on a miss:

```matlab
validChannels = {'ulmix', 'allUL', 'dlmix', 'allDL', 'launchPatternFile', 'bfw', 'allChannels'};
...
for i = 1:length(channelSet)
    if ~ismember(channelSet{i}, validChannels)
        error('Invalid channelSet: %s. Must be one of: %s', channelSet{i}, strjoin(validChannels, ', '));
    end
end
```

MATLAB's `ismember` is case-sensitive, so `'AllChannels'` never matches and the call aborts before any performance test vector is generated.

The lowercase spelling is the one used everywhere else in the tree — `nr_matlab/runRegression.m`, `nr_matlab/run5GModelCicd.m`, `aerial_mcore/scripts/gen_e2e_tvs.sh`, `aerial_mcore/QuickStart.md`, and `genPerfPattern.m`'s own defaults and docstring — so this is a typo in the one caller rather than an alias the validator should learn.

This patch corrects the spelling in the live call and in the commented-out `runRegression` alternative directly below it, so the commented form does not reintroduce the same failure if someone switches to it.
