### PR TITLE
fh-driver: allow opting out of the fatal NIC link-down check

### DIFF
--- a/cuPHY-CP/aerial-fh-driver/lib/nic.cpp
+++ b/cuPHY-CP/aerial-fh-driver/lib/nic.cpp
@@ -25,6 +25,8 @@
 #include <time.h>
 #include <stdio.h>
 #include <net/if.h>
+#include <cstdlib>
+#include <cstring>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -606,7 +608,21 @@ void Nic::check_physical_link_status() const
 
     if(link.link_status == RTE_ETH_LINK_DOWN)
     {
-        NVLOGF_FMT(TAG, AERIAL_DPDK_API_EVENT, "NIC {} has no physical Ethernet link (cable unplugged or peer port down)", info_.name);
+        // A missing physical link is fatal by default. Cable-less bring-up
+        // (development workstations, CI without a wired RU, pre-RU lab setups)
+        // can set AERIAL_FH_LINK_REQUIRED=0 to downgrade this to an error and
+        // let initialization continue. The comparison is an exact string match
+        // rather than an integer parse, so that anything unrecognized -- an
+        // empty value, "false", a typo -- leaves the fatal default in place.
+        const char* link_required_env = std::getenv("AERIAL_FH_LINK_REQUIRED");
+        if((link_required_env != nullptr) && (std::strcmp(link_required_env, "0") == 0))
+        {
+            NVLOGE_FMT(TAG, AERIAL_DPDK_API_EVENT, "NIC {} has no physical Ethernet link (cable unplugged or peer port down); continuing because AERIAL_FH_LINK_REQUIRED=0", info_.name);
+        }
+        else
+        {
+            NVLOGF_FMT(TAG, AERIAL_DPDK_API_EVENT, "NIC {} has no physical Ethernet link (cable unplugged or peer port down)", info_.name);
+        }
     }
 
     NVLOGI_FMT(TAG, "NIC {} link status: {}, {}, {}",


### PR DESCRIPTION
Addresses #41.

`Nic::check_physical_link_status()` reports a down link through `NVLOGF_FMT`:

```cpp
if(link.link_status == RTE_ETH_LINK_DOWN)
{
    NVLOGF_FMT(TAG, AERIAL_DPDK_API_EVENT, "NIC {} has no physical Ethernet link ...", info_.name);
}
```

`NVLOGF_FMT` ends in `pExitHandler.test_trigger_exit()` (`cuPHY/nvlog/include/nvlog_fmt.hpp:151`), so the process terminates inside `Nic::init()` — the call sits at `nic.cpp:80`, before any cell-level processing.

That is the right default for a deployed DU. It also means `ru_emulator` and `cuphycontroller_scf` cannot be brought up at all on a host whose fronthaul ports have no carrier: a development workstation with no DAC attached, or CI not yet wired to a real RU. There is currently no way to proceed, even though the rest of the L1 stack would initialize normally.

## Approach

#41 offered two options: downgrade the severity outright, or add a knob. This PR takes the second, in its least invasive form.

`NVLOGF` remains the default. When `AERIAL_FH_LINK_REQUIRED` is set to exactly `0`, the same condition is logged at `NVLOGE` and initialization continues; the log line names the variable so the downgrade is never silent in a captured log.

The value is compared with `strcmp`, not parsed with `atoi`. `atoi` maps every unrecognized string to `0` — including `false`, `off`, an empty value, and `true` — so an `atoi`-based check would silently disable the fatal path for all of them, which is the opposite of what the variable name implies. An exact string match keeps every unrecognized value on the fatal default. Nothing changes unless an operator sets the variable to `0`, so deployed and CI behaviour is unaffected by this patch.

The environment-variable form follows the existing `AERIAL_MEMTRACE` check in `cuPHY-CP/aerial-fh-driver/lib/gpu_comm.cpp:57`, and keeps the change to a single file. The alternative — a `link_required` key on the YAML `nics:` list — would mean adding a field to the public `NicInfo` struct in `aerial-fh-driver/include/aerial-fh-driver/api.hpp`, which is aggregate-initialized positionally by the in-tree tests, plus parser changes in `cuphycontroller/src/yamlparser.cpp` and in ru_emulator's own configuration path.

If you would rather have the YAML key than the environment variable, or would prefer this expressed as a per-NIC setting rather than a process-wide one, I am glad to re-plumb it — the policy question is yours, and this PR is deliberately scoped so that either shape stays cheap.

## Note on scope

#45 requests the same kind of policy control for the `EXIT_L1(EXIT_FAILURE)` sites in `cuPHY-CP/cuphydriver/src/uplink/task_function_ul_aggr.cpp` (eight of them in this release, at lines 515, 777, 958, 1137, 1302, 1526, 1944 and 2189). An `slot_map->abortTasks(); ... return -1;` sequence sits immediately after each one and is unreachable today; the accompanying comment states that pipeline recovery from CUDA/FH errors is not currently supported, so I make no claim about what that code was intended for.

That request touches the UL runtime hot path and a broader policy question about which failures may be treated as recoverable, so it is deliberately not part of this PR.
