### PR TITLE
fix(ldpc): include CRC length in code block segmentation decision

### DIFF
--- a/pyaerial/src/aerial/phy5g/ldpc/util.py
+++ b/pyaerial/src/aerial/phy5g/ldpc/util.py
@@ -498,8 +498,9 @@ def get_num_code_blocks(tb_size: int, code_rate: float) -> int:
     # Check if this TB size requires code block segmentation.
     crc_len = 24
     max_cb_size = max_code_block_size(base_graph)
-    if tb_size > max_cb_size:
-        num_code_blocks = math.ceil(tb_size / (max_cb_size - crc_len))
+    tb_size_with_crc = add_crc_len(tb_size)
+    if tb_size_with_crc > max_cb_size:
+        num_code_blocks = math.ceil(tb_size_with_crc / (max_cb_size - crc_len))
     else:
         num_code_blocks = 1
 


### PR DESCRIPTION
## Summary
`get_num_code_blocks()` decided whether to segment a transport block using the **raw** TB size, while its sibling `get_code_block_num_info_bits()` makes the same decision **after** `add_crc_len()`. For TB sizes in `(max_cb_size − 24, max_cb_size]` the two disagree: segmentation is applied but only one code block is allocated, so `code_block_segment()` / `code_block_desegment()` crash with a shape mismatch.

## Root cause
```python
# get_num_code_blocks()
if tb_size > max_cb_size:            # CRC length not accounted for

# get_code_block_num_info_bits() (line ~450)
tb_size = add_crc_len(tb_size)       # +16 or +24 depending on TB size
```
Per TS 38.212 §5.2.2, segmentation applies when the TB **with CRC attached** exceeds the maximum code block size.

## Fix
One-line change to make both functions use the same basis:
```python
if add_crc_len(tb_size) > max_cb_size:
```

## Testing
- ⚠️ **Not run locally** — `aerial.phy5g.ldpc.util` imports `aerial.pycuphy` (CUDA/cuPHY stack), which is unavailable on the authoring machine. Please rely on GPU CI.
- The change is a consistency fix: it reuses the existing `add_crc_len()` helper already applied in `get_code_block_num_info_bits()` and `code_block_segment()`.